### PR TITLE
feat(config): Add full support for macOS platform

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,8 @@
+v2.4.1 - 2025-10-16
+### Fixed
+- **macOS:** Added the default mods path for macOS (`~/Library/Application Support/VintagestoryData/Mods`) to ensure the application can locate the game's mod directory.
+- **macOS:** Corrected the update script URL for the macOS (Darwin) release, which was preventing the application from checking for new versions.
+
 v2.4.0 - 2025-10-14
 ### Added
 - **Build Automation:** Implemented a GitHub Actions workflow to automatically build and create releases for Windows (.exe), Linux (AppImage), and macOS (.dmg).

--- a/config.py
+++ b/config.py
@@ -54,7 +54,8 @@ XDG_CONFIG_HOME_PATH = os.getenv('XDG_CONFIG_HOME', os.path.expanduser('~/.confi
 
 MODS_PATHS = {
     "Windows": Path(HOME_PATH) / 'AppData' / 'Roaming' / 'VintagestoryData' / 'Mods',
-    "Linux": Path(XDG_CONFIG_HOME_PATH) / 'VintagestoryData' / 'Mods'
+    "Linux": Path(XDG_CONFIG_HOME_PATH) / 'VintagestoryData' / 'Mods',
+    "Darwin": Path(HOME_PATH) / 'Library' / 'Application Support' / 'VintagestoryData' / 'Mods'
 }
 
 # Retrieve the application directory from the APPDIR environment variable
@@ -136,7 +137,8 @@ URL_BASE_MODS = 'https://mods.vintagestory.at/'
 URL_MOD_DB = "https://mods.vintagestory.at/show/mod/"
 URL_SCRIPT = {
     "windows": 'https://mods.vintagestory.at/api/mod/1403',
-    "linux": 'https://mods.vintagestory.at/api/mod/1525'
+    "linux": 'https://mods.vintagestory.at/api/mod/1525',
+    "darwin": 'https://mods.vintagestory.at/api/mod/5583'
 }
 
 # Default configuration


### PR DESCRIPTION
This commit introduces the necessary configurations to make the application fully functional on macOS (Darwin).

- **MODS_PATHS:** Added the standard mod directory path for macOS (`~/Library/Application Support/VintagestoryData/Mods`). This allows the application to correctly locate the user's mod folder.
- **URL_SCRIPT:** Added the specific API endpoint for the macOS version of the updater script. This corrects a critical bug that prevented the application from checking for updates on macOS.